### PR TITLE
bad argument #1 to 'unpack' (got nil)

### DIFF
--- a/say_it_again.lua
+++ b/say_it_again.lua
@@ -803,7 +803,11 @@ end
 
 function log(msg, ...)
     if sia_settings.log_enable then
-        vlc.msg.info("[sia] " .. tostring(msg), unpack(arg))
+        if arg == nil then
+            vlc.msg.info("[sia] " .. tostring(msg))
+        else
+            vlc.msg.info("[sia] " .. tostring(msg), unpack(arg))
+        end
     end
 end
 


### PR DESCRIPTION
``` 
lua generic warning: Error while running script /home/bjorn/.local/share/vlc/lua/extensions/say_it_again.lua, function activate(): ...e/bjorn/.local/share/vlc/lua/extensions/say_it_again.lua:845: bad argument #1 to 'unpack' (table expected, got nil)
``` 

-------
My system
>Linux machine 3.16.7.3-1-MANJARO
>VLC media player 3.0.0-git Vetinari (revision 2.2.0-git-2055-g014a020)